### PR TITLE
FREEPBX-9512 avoid runtime errors

### DIFF
--- a/classes/digium_phones.php
+++ b/classes/digium_phones.php
@@ -99,8 +99,11 @@ class digium_phones {
 	}
 
 	public function cache_core_devices_list() {
-		foreach(core_devices_list('all', 'full') as $device) {
-			$this->core_devices[$device['id']] = $device;
+		$devices = core_devices_list('all', 'full');
+		if (!empty($devices) && is_array($devices)) {
+			foreach($devices as $device) {
+				$this->core_devices[$device['id']] = $device;
+			}
 		}
 	}
 
@@ -917,7 +920,7 @@ class digium_phones {
 
 		// Device settings
 		$devicesettings = array();
-		foreach ($device['settings'] as $key=>$val) {
+		if (!empty($device['settings'])) foreach ($device['settings'] as $key=>$val) {
 			if ($val != '') {
 				$devicesettings[] = '\''.$db->escapeSimple($deviceid).'\',\''.$db->escapeSimple($key).'\',\''.$db->escapeSimple($val).'\'';
 			}
@@ -936,7 +939,7 @@ class digium_phones {
 
 		// Lines
 		$lines = array();
-		foreach ($device['lines'] as $lineid=>$line) {
+		if (!empty($device['lines'])) foreach ($device['lines'] as $lineid=>$line) {
 			$lines[] = '\''.$db->escapeSimple($lineid).'\',\''.$db->escapeSimple($deviceid).'\',\''.$db->escapeSimple($line['extension']).'\'';
 		}
 
@@ -953,7 +956,7 @@ class digium_phones {
 
 		// Device phonebooks
 		$phonebooks = array();
-		foreach ($device['phonebooks'] as $phonebookentryid=>$phonebook) {
+		if (!empty($device['phonebooks'])) foreach ($device['phonebooks'] as $phonebookentryid=>$phonebook) {
 			$phonebooks[] = '\''.$db->escapeSimple($phonebookentryid).'\',\''.$db->escapeSimple($deviceid).'\',\''.$db->escapeSimple($phonebook['phonebookid']).'\'';
 		}
 
@@ -970,7 +973,7 @@ class digium_phones {
 
 		// Device networks
 		$networks = array();
-		foreach ($device['networks'] as $networkentryid=>$network) {
+		if (!empty($device['networks'])) foreach ($device['networks'] as $networkentryid=>$network) {
 			$networks[] = '\''.$db->escapeSimple($networkentryid).'\',\''.$db->escapeSimple($deviceid).'\',\''.$db->escapeSimple($network['networkid']).'\'';
 		}
 
@@ -987,7 +990,7 @@ class digium_phones {
 
 		// Device external lines
 		$externallines = array();
-		foreach ($device['externallines'] as $externallineentryid=>$externalline) {
+		if (!empty($device['externallines'])) foreach ($device['externallines'] as $externallineentryid=>$externalline) {
 			$externallines[] = '\''.$db->escapeSimple($externallineentryid).'\',\''.$db->escapeSimple($deviceid).'\',\''.$db->escapeSimple($externalline['externallineid']).'\'';
 		}
 
@@ -1004,7 +1007,7 @@ class digium_phones {
 
 		// Device logos
 		$logos = array();
-		foreach ($device['logos'] as $logoentryid=>$logo) {
+		if (!empty($device['logos'])) foreach ($device['logos'] as $logoentryid=>$logo) {
 			$logos[] = '\''.$db->escapeSimple($logoentryid).'\',\''.$db->escapeSimple($deviceid).'\',\''.$db->escapeSimple($logo['logoid']).'\'';
 		}
 
@@ -1021,7 +1024,7 @@ class digium_phones {
 
 		// Device alerts
 		$alerts = array();
-		foreach ($device['alerts'] as $alertentryid=>$alert) {
+		if (!empty($device['alerts'])) foreach ($device['alerts'] as $alertentryid=>$alert) {
 			$alerts[] = '\''.$db->escapeSimple($alertentryid).'\',\''.$db->escapeSimple($deviceid).'\',\''.$db->escapeSimple($alert['alertid']).'\'';
 		}
 
@@ -1038,7 +1041,7 @@ class digium_phones {
 
 		// Device ringtones
 		$ringtones = array();
-		foreach ($device['ringtones'] as $ringtoneentryid=>$ringtone) {
+		if (!empty($device['ringtones'])) foreach ($device['ringtones'] as $ringtoneentryid=>$ringtone) {
 			$ringtones[] = '\''.$db->escapeSimple($ringtoneentryid).'\',\''.$db->escapeSimple($deviceid).'\',\''.$db->escapeSimple($ringtone['ringtoneid']).'\'';
 		}
 
@@ -1055,7 +1058,7 @@ class digium_phones {
 
 		// Device statuses
 		$statuses = array();
-		foreach ($device['statuses'] as $statusentryid=>$status) {
+		if (!empty($device['statuses'])) foreach ($device['statuses'] as $statusentryid=>$status) {
 			$statuses[] = '\''.$db->escapeSimple($statusentryid).'\',\''.$db->escapeSimple($deviceid).'\',\''.$db->escapeSimple($status['statusid']).'\'';
 		}
 
@@ -1072,7 +1075,7 @@ class digium_phones {
 
 		// Device customapps
 		$customapps = array();
-		foreach ($device['customapps'] as $customappentryid=>$customapp) {
+		if (!empty($device['customapps'])) foreach ($device['customapps'] as $customappentryid=>$customapp) {
 			$customapps[] = '\''.$db->escapeSimple($customappentryid).'\',\''.$db->escapeSimple($deviceid).'\',\''.$db->escapeSimple($customapp['customappid']).'\'';
 		}
 
@@ -1278,7 +1281,7 @@ class digium_phones {
 		$entries = array();
 		$settings = array();
 		$newid = 0;
-		foreach ($phonebook['entries'] as $entryid=>$entry) {
+		if (!empty($phonebook['entries'])) foreach ($phonebook['entries'] as $entryid=>$entry) {
 			if ($entry == null) {
 				continue;
 			}

--- a/classes/digium_phones_firmware_package.php
+++ b/classes/digium_phones_firmware_package.php
@@ -174,7 +174,7 @@ class digium_phones_firmware_package {
 			return false;
 		}
 		unset($result);
-		rmdir($this->file_path);
+		@rmdir($this->file_path);
 		$this->file_path = $value;
 		needreload();
 		return true;

--- a/conf/res_digium_phone_devices.php
+++ b/conf/res_digium_phone_devices.php
@@ -35,6 +35,8 @@ function res_digium_phone_devices($conf) {
 	$firmware_manager = $conf->digium_phones->get_firmware_manager();
 	$default_locale = $conf->digium_phones->get_general('active_locale');
 	$output = array();
+	$doutput = array();
+	$loutput = array();
 
 	foreach ($conf->digium_phones->get_devices() as $deviceid=>$device) {
 		$doutput[] = "[{$deviceid}]";
@@ -79,7 +81,7 @@ function res_digium_phone_devices($conf) {
 		}
 		$doutput[] = "application={$vm_app}";
 
-		foreach ($device['settings'] as $key=>$val) {
+		if (!empty($device['settings'])) foreach ($device['settings'] as $key=>$val) {
 			if ($key == 'rapiddial') {
 				if ($val == '') {
 					continue;
@@ -125,7 +127,7 @@ function res_digium_phone_devices($conf) {
 		}
 
 		$doutput[] = "use_local_storage=yes";
-		foreach ($device['phonebooks'] as $phonebook) {
+		if (!empty($device['phonebooks'])) foreach ($device['phonebooks'] as $phonebook) {
 			if ($phonebook['phonebookid'] == $device['settings']['rapiddial']) {
 				continue;
 			}
@@ -136,16 +138,16 @@ function res_digium_phone_devices($conf) {
 			}
 		}
 
-		foreach ($device['networks'] as $network) {
+		if (!empty($device['networks'])) foreach ($device['networks'] as $network) {
 			$doutput[] = "network=network-{$network['networkid']}";
 		}
 
-		foreach ($device['logos'] as $dl) {
+		if (!empty($device['logos'])) foreach ($device['logos'] as $dl) {
 			$logo = $conf->digium_phones->get_logo($dl['logoid']);
 
 			$doutput[] = "{$logo['model']}_logo_file=user_image_{$logo['id']}.png";
 		}
-		foreach ($device['alerts'] as $alert) {
+		if (!empty($device['alerts'])) foreach ($device['alerts'] as $alert) {
 			$doutput[] = "alert=alert-{$alert['alertid']}";
 			$alerts = $conf->digium_phones->get_alerts();
 			$ringtone_id = $alerts[$alert['alertid']]['ringtone_id'];
@@ -153,7 +155,7 @@ function res_digium_phone_devices($conf) {
 				$ringtones[$alerts[$alert['alertid']]['ringtone_id']] = true;
 			}
 		}
-		foreach ($device['ringtones'] as $ringtone) {
+		if (!empty($device['ringtones'])) foreach ($device['ringtones'] as $ringtone) {
 			$ringtones[$ringtone['ringtoneid']] = true;
 		}
 		foreach ($ringtones as $id => $istrue) {
@@ -165,7 +167,7 @@ function res_digium_phone_devices($conf) {
 			$doutput[] = "blf_contact_group=internal-{$device['id']}";
 		}
 */
-		foreach ($device['lines'] as $lineid=>$line) {
+		if (!empty($device['lines'])) foreach ($device['lines'] as $lineid=>$line) {
 			$doutput[] = "line={$line['extension']}";
 			$loutput[] = "[{$line['extension']}]";
 			$loutput[] = "type=line";
@@ -183,7 +185,7 @@ function res_digium_phone_devices($conf) {
 			$loutput[] = "";
 		}
 
-		foreach ($device['externallines'] as $externalline) {
+		if (!empty($device['externallines'])) foreach ($device['externallines'] as $externalline) {
 			$doutput[] = "external_line=externalline-{$externalline['externallineid']}";
 		}
 
@@ -200,12 +202,12 @@ function res_digium_phone_devices($conf) {
 				$doutput[] = "application=status-{$type}";
 			}
 		} else {
-			foreach ($device['statuses'] as $status) {
+			if (!empty($device['statuses'])) foreach ($device['statuses'] as $status) {
 				$doutput[] = "application=status-{$status['statusid']}";
 			}
 		}
 
-		foreach ($device['customapps'] as $customapp) {
+		if (!empty($device['customapps'])) foreach ($device['customapps'] as $customapp) {
 			$doutput[] = "application=customapp-{$customapp['customappid']}";
 		}
 

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -384,7 +384,7 @@ class digium_phones_conf {
 			$files[] = 'digium_phones/contacts-internal-' . $device['id'] . '.xml';
 		}
 
-		mkdir("{$amp_conf['ASTETCDIR']}/digium_phones/", 0755);
+		@mkdir("{$amp_conf['ASTETCDIR']}/digium_phones/", 0755);
 		foreach (glob("{$amp_conf['ASTETCDIR']}/digium_phones/contacts-internal-*.xml") as $file) {
 			unlink($file);
 		}

--- a/page.digium_phones.php
+++ b/page.digium_phones.php
@@ -117,7 +117,7 @@ if (isset($_POST['general_submit'])) {
 		$device['settings'][$setting] = $_POST[$setting];
 	}
 
-	foreach ($_POST['lines'] as $exten) {
+	if (!empty($_POST['lines'])) foreach ($_POST['lines'] as $exten) {
 		$line = array();
 		if (substr($exten, 0, 9) == "external:") {
 			$exten = substr($exten, 9);
@@ -144,7 +144,7 @@ if (isset($_POST['general_submit'])) {
 		}
 	}
 
-	foreach ($_POST['devicephonebooks'] as $phonebookid) {
+	if (!empty($_POST['devicephonebooks'])) foreach ($_POST['devicephonebooks'] as $phonebookid) {
 		$phonebook = array();
 		$phonebook['phonebookid'] = $phonebookid;
 		foreach ($olddevice['phonebooks'] as $p) {
@@ -156,7 +156,7 @@ if (isset($_POST['general_submit'])) {
 		$device['phonebooks'][] = $phonebook;
 	}
 
-	foreach ($_POST['devicenetworks'] as $networkid) {
+	if (!empty($_POST['devicenetworks'])) foreach ($_POST['devicenetworks'] as $networkid) {
 		$network = array();
 		$network['networkid'] = $networkid;
 		foreach ($olddevice['networks'] as $n) {
@@ -168,7 +168,7 @@ if (isset($_POST['general_submit'])) {
 		$device['networks'][] = $network;
 	}
 
-	foreach ($_POST['devicelogos'] as $logoid) {
+	if (!empty($_POST['devicelogos'])) foreach ($_POST['devicelogos'] as $logoid) {
 		$logo = array();
 		$logo['logoid'] = $logoid;
 		foreach ($olddevice['logos'] as $l) {
@@ -180,7 +180,7 @@ if (isset($_POST['general_submit'])) {
 		$device['logos'][] = $logo;
 	}
 
-	foreach ($_POST['devicealerts'] as $alertid) {
+	if (!empty($_POST['devicealerts'])) foreach ($_POST['devicealerts'] as $alertid) {
 		$alert = array();
 		$alert['alertid'] = $alertid;
 		foreach ($olddevice['alerts'] as $a) {
@@ -192,7 +192,7 @@ if (isset($_POST['general_submit'])) {
 		$device['alerts'][] = $alert;
 	}
 
-	foreach ($_POST['deviceringtones'] as $ringtoneid) {
+	if (!empty($_POST['deviceringtones'])) foreach ($_POST['deviceringtones'] as $ringtoneid) {
 		$ringtone = array();
 		$ringtone['ringtoneid'] = $ringtoneid;
 		foreach ($olddevice['ringtones'] as $a) {
@@ -204,7 +204,7 @@ if (isset($_POST['general_submit'])) {
 		$device['ringtones'][] = $ringtone;
 	}
 
-	foreach ($_POST['devicestatuses'] as $statusid) {
+	if (!empty($_POST['devicestatuses'])) foreach ($_POST['devicestatuses'] as $statusid) {
 		$status = array();
 		$status['statusid'] = $statusid;
 		foreach ($olddevice['statuses'] as $s) {
@@ -216,7 +216,7 @@ if (isset($_POST['general_submit'])) {
 		$device['statuses'][] = $status;
 	}
 
-	foreach ($_POST['devicecustomapps'] as $customappid) {
+	if (!empty($_POST['devicecustomapps'])) foreach ($_POST['devicecustomapps'] as $customappid) {
 		$customapp = array();
 		$customapp['customappid'] = $customappid;
 		foreach ($olddevice['customapps'] as $c) {
@@ -378,7 +378,7 @@ if (isset($_POST['general_submit'])) {
 	$queue = array();
 	$queue['id'] = $queueid;
 
-	foreach ($_POST['managers'] as $manager) {
+	if (!empty($_POST['managers'])) foreach ($_POST['managers'] as $manager) {
 		$entry = array();
 		$entry['deviceid'] = $manager;
 		$entry['permission'] = "details";
@@ -386,7 +386,7 @@ if (isset($_POST['general_submit'])) {
 		$queue['entries'][] = $entry;
 	}
 
-	foreach ($_POST['permissions'] as $deviceid=>$perm) {
+	if (!empty($_POST['permissions'])) foreach ($_POST['permissions'] as $deviceid=>$perm) {
 		if ($perm == "none") {
 			// There's no need to write this out.
 			continue;
@@ -411,7 +411,7 @@ if (isset($_POST['general_submit'])) {
 
 	$status['entries'] = array();
 
-	foreach ($_POST['entries'] as $entry) {
+	if (!empty($_POST['entries'])) foreach ($_POST['entries'] as $entry) {
 		$status['entries'][] = $entry;
 	}
 
@@ -447,7 +447,7 @@ if (isset($_POST['general_submit'])) {
 		$customapp['settings'][$setting] = $_POST[$setting];
 	}
 
-	foreach ($_POST['entries'] as $entry) {
+	if (!empty($_POST['entries'])) foreach ($_POST['entries'] as $entry) {
 		$kv = preg_split('/=/', $entry);
 
 		if (in_array($kv[0], $settings)) {

--- a/views/digium_phones_application_queues.php
+++ b/views/digium_phones_application_queues.php
@@ -180,7 +180,7 @@ foreach ($queues as $queueid=>$queue) {
 	echo '<ul id="managersS" class="devices ui-menu ui-widget ui-widget-content ui-corner-all ui-sortable">';
 
 	
-	foreach( $queues[$editqueue]['entries'] as $id=>$details){
+	if (!empty($queues[$editqueue]['entries'])) foreach( $queues[$editqueue]['entries'] as $id=>$details){
 		if($details['permission'] == 'details'){echo '<li id="' . $id . '">' . $devices[$id]['name'] . '</li>';}
 	}
 

--- a/views/digium_phones_phonebooks.php
+++ b/views/digium_phones_phonebooks.php
@@ -62,7 +62,7 @@ foreach ($phonebooks as $phonebookid=>$phonebook) {
 		continue;
 	}
 	if ($editpb == $phonebookid) {
-		foreach ($phonebook['entries'] as $entryid=>$entry) {
+		if (!empty($phonebook['entries'])) foreach ($phonebook['entries'] as $entryid=>$entry) {
 			if ($editentry != null && $editentry == $entryid) {
 ?>
 				$('#extension').val('<?php echo $entry['extension']?>');
@@ -197,7 +197,7 @@ foreach ($phonebooks as $phonebookid=>$phonebook) {
 			continue;
 		}
 
-		foreach ($phonebook['entries'] as $entryid=>$entry) {
+		if (!empty($phonebook['entries'])) foreach ($phonebook['entries'] as $entryid=>$entry) {
 ?>
 	<tr>
 	<td valign="top" style="width: 200px; border-style:inset; border-width: 1px; ">

--- a/views/digium_phones_phones.php
+++ b/views/digium_phones_phones.php
@@ -64,7 +64,7 @@ if ($editdev == 0) {
 }
 
 
-foreach ($devices as $deviceid=>$device) {
+if (!empty($devices)) foreach ($devices as $deviceid=>$device) {
 	if ($editdev == $deviceid) {
 		if (isset($device['settings']['active_locale']) === FALSE) {
 			$general_locale = $digium_phones->get_general('active_locale');
@@ -72,7 +72,7 @@ foreach ($devices as $deviceid=>$device) {
 				$device['settings']['active_locale'] = $general_locale;
 			}
 		}
-		foreach ($device['settings'] as $key=>$val) {
+		if (!empty($device['settings'])) foreach ($device['settings'] as $key=>$val) {
 ?>
 			if ($('#<?php echo $key?>') != null) {
 				$('#<?php echo $key?>').val('<?php echo $val?>');
@@ -86,7 +86,7 @@ foreach ($devices as $deviceid=>$device) {
 <?php
 		}
 	}
-	foreach ($device["lines"] as $line) {
+	if (!empty($device['lines'])) foreach ($device["lines"] as $line) {
 		if ($editdev == $deviceid) {
 ?>
 			addEntry("<?php echo $line['extension']?>");
@@ -97,7 +97,7 @@ foreach ($devices as $deviceid=>$device) {
 <?php
 		}
 	}
-	foreach ($device["externallines"] as $externalline) {
+	if (!empty($device['externallines'])) foreach ($device["externallines"] as $externalline) {
 		if ($editdev == $deviceid) {
 ?>
 			addEntry("external:<?php echo $externalline['externallineid']?>");
@@ -105,7 +105,7 @@ foreach ($devices as $deviceid=>$device) {
 		}
 	}
 
-	foreach ($device["phonebooks"] as $phonebook) {
+	if (!empty($device['phonebooks'])) foreach ($device["phonebooks"] as $phonebook) {
 		if ($editdev == $deviceid) {
 ?>
 			addPhonebook("<?php echo $phonebook['phonebookid']?>");
@@ -113,7 +113,7 @@ foreach ($devices as $deviceid=>$device) {
 		}
 	}
 
-	foreach ($device["networks"] as $network) {
+	if (!empty($device['networks'])) foreach ($device["networks"] as $network) {
 		if ($editdev == $deviceid) {
 ?>
 			addNetwork("<?php echo $network['networkid']?>");
@@ -121,7 +121,7 @@ foreach ($devices as $deviceid=>$device) {
 		}
 	}
 
-	foreach ($device["logos"] as $logo) {
+	if (!empty($device['logos'])) foreach ($device["logos"] as $logo) {
 		if ($editdev == $deviceid) {
 ?>
 			addLogo("<?php echo $logo['logoid']?>");
@@ -129,14 +129,14 @@ foreach ($devices as $deviceid=>$device) {
 		}
 	}
 
-	foreach ($device["alerts"] as $alert) {
+	if (!empty($device['alerts'])) foreach ($device["alerts"] as $alert) {
 		if ($editdev == $deviceid) {
 ?>
 			addAlert("<?php echo $alert['alertid']?>");
 <?php
 		}
 	}
-	foreach ($device["ringtones"] as $ringtone) {
+	if (!empty($device['ringtones'])) foreach ($device["ringtones"] as $ringtone) {
 		if ($editdev == $deviceid) {
 ?>
 			addAlert("<?php echo $ringtone['ringtoneid']?>");
@@ -144,7 +144,7 @@ foreach ($devices as $deviceid=>$device) {
 		}
 	}
 
-	foreach ($device["statuses"] as $status) {
+	if (!empty($device['statuses'])) foreach ($device["statuses"] as $status) {
 		if ($editdev == $deviceid) {
 ?>
 			addStatus("<?php echo $status['statusid']?>");
@@ -152,7 +152,7 @@ foreach ($devices as $deviceid=>$device) {
 		}
 	}
 
-	foreach ($device["customapps"] as $customapp) {
+	if (!empty($device['customapps'])) foreach ($device["customapps"] as $customapp) {
 		if ($editdev == $deviceid) {
 ?>
 			addCustomApp("<?php echo $customapp['customappid']?>");
@@ -452,7 +452,7 @@ if ($response && array_key_exists('data', $response)) {
 	$sessions = preg_split('/\n/', $response['data']);
 }
 
-foreach ($devices as $deviceid=>$device) {
+if (!empty($devices)) foreach ($devices as $deviceid=>$device) {
 ?>
 <tr>
 	<td style="border-style:inset; border-width: 1px; ">
@@ -463,7 +463,7 @@ foreach ($devices as $deviceid=>$device) {
 <?php
 	$first_internal_line = null;
 	$linecount=0;
-	foreach ($device['lines'] as $line) {
+	if (!empty($device['lines'])) foreach ($device['lines'] as $line) {
 		$linecount++;
 ?>
 		<tr>
@@ -490,7 +490,7 @@ foreach ($devices as $deviceid=>$device) {
 <?php
 	}
 
-	foreach ($device['externallines'] as $externalline) {
+	if (!empty($device['externallines'])) foreach ($device['externallines'] as $externalline) {
 		$el = $digium_phones->get_externalline($externalline['externallineid']);
 
 		if ($el == null) {
@@ -649,10 +649,10 @@ echo $table->generate();
 $table->clear();
 
 $devices = $digium_phones->get_device($editdev);
-foreach( $devices['lines'] as $device){
+if (!empty($devices['lines'])) foreach( $devices['lines'] as $device){
 	$used[$device['extension']] = $device['extension'];
 }
-foreach( $devices['externallines'] as $device){
+if (!empty($devices['externallines'])) foreach( $devices['externallines'] as $device){
 	$usedE[$device['externallineid']] = $device['externallineid'];
 }
 
@@ -680,7 +680,7 @@ echo '<div class="dragdrop">';
 echo fpbx_label('Assigned Extensions', 'Displays a listing of extensions, ordered by Line number, beginning with the first line, assigned to the phone.');
 echo '<ul id="lines" class="ext ui-menu ui-widget ui-widget-content ui-corner-all ui-sortable">';
 echo 'Internal';
-foreach( $devices['lines'] as $device){
+if (!empty($devices['lines'])) foreach( $devices['lines'] as $device){
 	echo '<li id="lines_' . $device['extension'] . '">' . $device['extension'] . '</li>';
 }
 
@@ -688,7 +688,7 @@ echo '<br />External';
 
 $externals = $digium_phones->get_externallines();
 
-foreach($devices['externallines'] as $external){
+if (!empty($devices['externallines'])) foreach($devices['externallines'] as $external){
 	foreach($externals as $vals){
 		if($vals['id'] == $external['externallineid']){$name = $vals['name'];}
 	}
@@ -701,7 +701,7 @@ echo '<div style="clear:both;" />';
 
 //phonebooks
 $phonebooks = $digium_phones->get_phonebooks();
-foreach($devices['phonebooks'] as $pb){
+if (!empty($devices['phonebooks'])) foreach($devices['phonebooks'] as $pb){
 	$phonebooksSelected[$pb['phonebookid']] = $pb['phonebookid'];
 }
 echo '<div class="dragdropFrame">';
@@ -757,7 +757,7 @@ $table->clear();
 foreach ($digium_phones->get_networks() as $network) {
 	$networks[$network['id']] = $network['name'];
 }
-foreach($devices['networks'] as $net){
+if (!empty($devices['networks'])) foreach($devices['networks'] as $net){
 	$networksSelected[$net['networkid']] = $net['networkid'];
 }
 echo '<div class="dragdropFrame">';
@@ -774,7 +774,7 @@ echo '</div>';
 echo '<div class="dragdrop">';
 echo fpbx_label('Assigned Networks', 'Displays a listing of networks currently assigned to a phone. By default, a Default Network is assigned to the phone.');
 echo '<ul id="devicenetworks" class="networks ui-menu ui-widget ui-widget-content ui-corner-all ui-sortable">';
-foreach( $networksSelected as $net){
+if ($networksSelected) foreach( $networksSelected as $net){
 	echo '<li id="devicenetworks_' . $net . '">' . $networks[$net] . '</li>';
 }
 echo '</ul>';
@@ -795,7 +795,7 @@ echo '<div class="dragdropFrame">';
 echo '<div class="dragdrop">';
 echo fpbx_label('Available Logos', 'Displays a listing of logos that may be assigned to the phone. More than one logo may be assigned to a phone.');
 echo '<ul id="availableLogos" class="logos ui-menu ui-widget ui-widget-content ui-corner-all ui-sortable">';
-foreach ($logos as $id=>$logo){
+if ($logos) foreach ($logos as $id=>$logo){
 	if(empty($logosSelected[$id])){
 		echo '<li id="devicelogos_' . $id . '">' . $logo . '</li>';
 	}
@@ -828,7 +828,7 @@ echo '<div class="dragdropFrame">';
 echo '<div class="dragdrop">';
 echo fpbx_label('Available Alerts', 'Displays a listing of alerts that may be assigned to the phone. More than one alert may be assigned to a phone.');
 echo '<ul id="availableAlerts" class="alerts ui-menu ui-widget ui-widget-content ui-corner-all ui-sortable">';
-foreach ($alerts as $id=>$name){
+if ($alerts) foreach ($alerts as $id=>$name){
 	if(empty($alertsSelected[$id])){
 		echo '<li id="devicealerts_' . $id . '">' . $name . '</li>';
 	}
@@ -863,7 +863,7 @@ echo '<div class="dragdropFrame">';
 echo '<div class="dragdrop">';
 echo fpbx_label('Available Ringtones', 'Displays a listing of ringtones that may be assigned to the phone. More than one ringtone may be assigned to a phone.');
 echo '<ul id="availableringtones" class="ringtones ui-menu ui-widget ui-widget-content ui-corner-all ui-sortable">';
-foreach ($ringtones as $id=>$name){
+if ($ringtones) foreach ($ringtones as $id=>$name){
 	if(empty($ringtonesSelected[$id])){
 		echo '<li id="deviceringtones_' . $id . '">' . $name . '</li>';
 	}
@@ -922,7 +922,7 @@ if (!function_exists('presencestate_list_get')) {
 foreach ($digium_phones->get_customapps() as $data) {
 	$customapps[$data['id']] = $data['name'];
 }
-foreach($devices['customapps'] as $data){
+if (!empty($devices['customapps'])) foreach($devices['customapps'] as $data){
 	$customappsSelected[$data['customappid']] = $data['customappid'];
 }
 echo '<div class="dragdropFrame">';
@@ -1171,5 +1171,17 @@ $table->clear();
 	<input type="button" value="Cancel" onclick="location.href='config.php?type=setup&display=digium_phones&digium_phones_form=phones_edit'"/>
 	<input type="hidden" name="editdevice_submit" value="Save"/>
 	<input type="submit" name="editdevice_submit" value="Save"/>
+
+<!-- This is a very long page - add several extra blank lines to insure buttons aren't hidden under logos -->
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+<br />
+
 </div>
 </form>


### PR DESCRIPTION
Collection of bugfixes to avoid runtime errors.  Mostly these check for an array with content before iterating it, but also adding error masking to certain filesystem commands.