### PR TITLE
FREEPBX-9976: support multiple parking lots

### DIFF
--- a/classes/digium_phones_models.php
+++ b/classes/digium_phones_models.php
@@ -38,9 +38,9 @@ class digium_phones_models {
 			'd40' => array('name' => 'D40', 'logo' => '150x45', 'color' => 0),
 			'd45' => array('name' => 'D45', 'logo' => '150x45', 'color' => 0),
 			'd50' => array('name' => 'D50', 'logo' => '150x45', 'color' => 0),
-			'd60' => array('name' => 'D60', 'logo' => '280x128', 'color' => 1),
-			'd62' => array('name' => 'D62', 'logo' => '280x128', 'color' => 1),
-			'd65' => array('name' => 'D65', 'logo' => '280x128', 'color' => 1),
+			'd60' => array('name' => 'D60', 'logo' => '296x128', 'color' => 1),
+			'd62' => array('name' => 'D62', 'logo' => '296x128', 'color' => 1),
+			'd65' => array('name' => 'D65', 'logo' => '296x128', 'color' => 1),
 			'd70' => array('name' => 'D70', 'logo' => '205x85', 'color' => 0),
 		);
 

--- a/conf/res_digium_phone_applications.php
+++ b/conf/res_digium_phone_applications.php
@@ -34,6 +34,7 @@ function res_digium_phone_applications($conf) {
 	$output = array();
 	$vm_apps = array();
 	$translations = array();
+	$parking_apps = array();
 
 	foreach ($conf->digium_phones->get_devices() as $deviceid=>$device) {
 		if (isset($device['settings']['active_locale']) === FALSE) {
@@ -83,6 +84,22 @@ function res_digium_phone_applications($conf) {
 			$output[] = "";
 		}
 		unset($table);
+
+		if (!empty($device['parkapps'])) {
+			foreach ($device['parkapps'] as $parkapp) {
+				if (!in_array($parkapp['category'], $parking_apps)) {
+					$parking_apps[] = $parkapp['category'];
+				}
+			}
+		}
+	}
+
+	foreach ($parking_apps as $category) {
+		$output[] = '[parking-app-' . $category . ']';
+		$output[] = 'type=application';
+		$output[] = 'application=parking';
+		$output[] = 'parkinglot='.$category;
+		$output[] = '';
 	}
 
 	foreach ($conf->digium_phones->get_queues() as $queueid=>$queue) {

--- a/conf/res_digium_phone_applications.php
+++ b/conf/res_digium_phone_applications.php
@@ -37,6 +37,15 @@ function res_digium_phone_applications($conf) {
 	$parking_apps = array();
 
 	foreach ($conf->digium_phones->get_devices() as $deviceid=>$device) {
+
+		if (!empty($device['parkapps'])) {
+			foreach ($device['parkapps'] as $parkapp) {
+				if (!in_array($parkapp['category'], $parking_apps)) {
+					$parking_apps[] = $parkapp['category'];
+				}
+			}
+		}
+
 		if (isset($device['settings']['active_locale']) === FALSE) {
 			$locale = $conf->digium_phones->get_general('active_locale');
 		} else {
@@ -84,14 +93,6 @@ function res_digium_phone_applications($conf) {
 			$output[] = "";
 		}
 		unset($table);
-
-		if (!empty($device['parkapps'])) {
-			foreach ($device['parkapps'] as $parkapp) {
-				if (!in_array($parkapp['category'], $parking_apps)) {
-					$parking_apps[] = $parkapp['category'];
-				}
-			}
-		}
 	}
 
 	foreach ($parking_apps as $category) {

--- a/conf/res_digium_phone_devices.php
+++ b/conf/res_digium_phone_devices.php
@@ -46,21 +46,18 @@ function res_digium_phone_devices($conf) {
 		/* collect which custom ringtones need to be loaded for this device */
 		$ringtones = array();
 
-		$parkext = "";
-		if (function_exists('parking_getconfig')) {
-			// Old and busted parking module
-			$parking = parking_getconfig();
-			if ($parking != null && $parking['parkingenabled'] != "" && $parking['parkext'] != "") {
-				$parkext = $parking['parkext'];
+		if (empty($device['setings']['parking_exten'])) {
+			$parkext = '';
+			if (!$parkext && function_exists('parking_get')) {
+				$parking = parking_get();
+				if (!empty($parking['parkext'])) {
+					$parkext = $parking['parkext'];
+				}
 			}
-		} else if (function_exists('parking_get')) {
-			// Fancy new 'park plus' module
-			$parking = parking_get();
-			if ($parking != null && $parking['parkext'] != "") {
-				$parkext = $parking['parkext'];
-			}
+
+			/* only output default parkext if it's not already set in device settings */
+			$doutput[] = "parking_exten={$parkext}";
 		}
-		$doutput[] = "parking_exten={$parkext}";
 		$doutput[] = "parking_transfer_type=blind";
 
 		if (isset($device['settings']['active_locale']) === FALSE) {

--- a/conf/res_digium_phone_devices.php
+++ b/conf/res_digium_phone_devices.php
@@ -78,6 +78,12 @@ function res_digium_phone_devices($conf) {
 		}
 		$doutput[] = "application={$vm_app}";
 
+		if (!empty($device['parkapps'])) {
+			foreach ($device['parkapps'] as $parkapp) {
+				$doutput[] = 'application=parking-app-'.$parkapp['category'];
+			}
+		}
+
 		if (!empty($device['settings'])) foreach ($device['settings'] as $key=>$val) {
 			if ($key == 'rapiddial') {
 				if ($val == '') {

--- a/install.php
+++ b/install.php
@@ -288,6 +288,13 @@ $queries[] = "CREATE TABLE IF NOT EXISTS digium_phones_device_mcpages (
 	PRIMARY KEY (`deviceid`, `mcpageid`)
 );";
 
+$queries[] = "CREATE TABLE IF NOT EXISTS digium_phones_device_parkapps (
+	`id` INT NOT NULL,
+	`deviceid` INT NOT NULL,
+	`category` VARCHAR(45),
+	PRIMARY KEY (`deviceid`, `category`)
+);";
+
 
 $queries[] = "CREATE TABLE IF NOT EXISTS digium_phones_pnacs (
 	`id` INT NOT NULL AUTO_INCREMENT,

--- a/page.digium_phones.php
+++ b/page.digium_phones.php
@@ -84,6 +84,7 @@ if (isset($_POST['general_submit'])) {
 	$device['phonebooks'] = array();
 	$device['networks'] = array();
 	$device['mcpages'] = array();
+	$device['parkapps'] = array();
 	$device['pnacs'] = array();
 	$device['externallines'] = array();
 	$device['logos'] = array();
@@ -195,6 +196,19 @@ if (isset($_POST['general_submit'])) {
 		}
 		$device['mcpages'][] = $mcpage;
 	}
+
+	if (!empty($_POST['deviceparkapps'])) foreach ($_POST['deviceparkapps'] as $category) {
+		$parkapp = array();
+		$parkapp['category'] = $category;
+		if (!empty($olddevice['parkapps'])) foreach ($olddevice['parkapps'] as $n) {
+			if ($n['category'] == $category) {
+				$parkapp = $n;
+				break;
+			}
+		}
+		$device['parkapps'][] = $parkapp;
+	}
+
 
 	if (!empty($_POST['devicelogos'])) foreach ($_POST['devicelogos'] as $logoid) {
 		$logo = array();

--- a/page.digium_phones.php
+++ b/page.digium_phones.php
@@ -126,6 +126,7 @@ if (isset($_POST['general_submit'])) {
 		'default_fontsize',
 		'call_waiting_tone',
 		'pnac_id',
+		'parking_exten',
 	);
 
 	foreach ($settings as $setting) {

--- a/views/digium_phones_phones.php
+++ b/views/digium_phones_phones.php
@@ -1039,6 +1039,22 @@ echo '</div>';
 echo '</div>'."\n"; // dragdropFrame
 echo '<div style="clear:both;"></div>'."\n";
 
+if (function_exists('parking_get')) {
+	$parking_lots = parking_get('all');
+} else {
+	$parking_lots = array(array('parkext' => '70', 'name' => 'Default Lot'));
+}
+
+$parklots = '<select id="parking_exten" name="parking_exten">';
+foreach (parking_get('all') as $lot) {
+	$parklots .= '<option value="' . $lot['parkext'] .'"';
+	if ($lot['parkext'] == $devices['settings']['parking_exten']) $parklots .= ' selected';
+	$parklots .= '>' . $lot['name'] . ' (' . $lot['parkext'] . ')</option>';
+}
+
+$table->add_row(array('data' => fpbx_label('Select Parking Lot:', 'Pick which lot to use for the one-touch Park button.')),
+			array('data' => $parklots));
+
 
 $table->add_row(array( 'data' => fpbx_label('Enable Call Recording:', 'Enables or Disables Call Recording. If disabled, the Record softkey will not show for in-progress calls.')),
 				array( 'data' => '<select id="record_own_calls" name="record_own_calls">

--- a/views/digium_phones_phones.php
+++ b/views/digium_phones_phones.php
@@ -1039,14 +1039,17 @@ echo '</div>';
 echo '</div>'."\n"; // dragdropFrame
 echo '<div style="clear:both;"></div>'."\n";
 
+
 if (function_exists('parking_get')) {
 	$parking_lots = parking_get('all');
 } else {
 	$parking_lots = array(array('parkext' => '70', 'name' => 'Default Lot'));
 }
 
+$parking_all = parking_get('all');
+
 $parklots = '<select id="parking_exten" name="parking_exten">';
-foreach (parking_get('all') as $lot) {
+foreach ($parking_all as $lot) {
 	$parklots .= '<option value="' . $lot['parkext'] .'"';
 	if ($lot['parkext'] == $devices['settings']['parking_exten']) $parklots .= ' selected';
 	$parklots .= '>' . $lot['name'] . ' (' . $lot['parkext'] . ')</option>';
@@ -1054,6 +1057,27 @@ foreach (parking_get('all') as $lot) {
 
 $table->add_row(array('data' => fpbx_label('Select Parking Lot:', 'Pick which lot to use for the one-touch Park button.')),
 			array('data' => $parklots));
+
+$parkapps = '<div style="overflow-y:auto; max-height:200px; border: 1px solid #aaaaaa; border-radius: 4px; padding: 2px;">';
+foreach ($parking_all as $lot) {
+	$id = 'deviceparkapps[]';
+	$value = 'parkinglot_'.$lot['id'];
+	if ($lot['defaultlot'] == 'yes') {
+		$value = 'default';
+	}
+	$name = $lot['name']. ' ('.$lot['parkpos'].'-'.($lot['parkpos']+$lot['numslots']-1).')';
+	$checked = '';
+	if (!empty($devices['parkapps'])) foreach ($devices['parkapps'] as $parkapp) {
+		if ($parkapp['category'] == $value) {
+			$checked = ' checked';
+		}
+	}
+	$parkapps .= '<input type="checkbox" name="'.$id.'" value="'.$value.'"'.$checked.'>'.$name.'<br>';
+}
+$parkapps.='</div>';
+
+$table->add_row(array('data' => fpbx_label('Visible Parking Lots:', 'Select lots that can be viewed on the phone parking application.  If none are selected, all parked calls will be shown.')),
+			array('data' => $parkapps));
 
 
 $table->add_row(array( 'data' => fpbx_label('Enable Call Recording:', 'Enables or Disables Call Recording. If disabled, the Record softkey will not show for in-progress calls.')),


### PR DESCRIPTION
Multiple parking lots from ParkingPro module are now fully supported.  The park button can be set to any individual lot, and the display of parked calls can be restricted to any set of lots.
