### PR TITLE
Fix for vm fwd issue and null array

### DIFF
--- a/classes/digium_phones.php
+++ b/classes/digium_phones.php
@@ -839,7 +839,7 @@ class digium_phones {
 		foreach ($devices as $device) {
 			$d = $device;
 			$d['lines'] = array();
-			foreach ($device['lines'] as $line) {
+			if (!empty($device['lines'])) foreach ($device['lines'] as $line) {
 				$l = $line;
 				$l['user'] = $this->get_core_device($line['extension']);
 				$d['lines'][] = $l;

--- a/conf/digium_phones_contacts.php
+++ b/conf/digium_phones_contacts.php
@@ -115,10 +115,10 @@ function digium_phones_contacts($conf, $internal, $extension) {
 			$output[] = '    organization=""';
 		}
 
+		$output[] = '    contact_type="sip"';
+		$output[] = '    account_id="' . htmlspecialchars($entry['extension']) . '"';
 		if ($customexten == false) {
 			// TODO: Not all contacts are SIP.  Or maybe it doesn't matter because it's SIP to Asterisk.  Who knows?
-			$output[] = '    contact_type="sip"';
-			$output[] = '    account_id="' . htmlspecialchars($entry['extension']) . '"';
 			if ($conf->autohint[$extension]) {
 				$output[] = '    subscribe_to="auto_hint_' . htmlspecialchars($entry['extension']) . '"';
 			} else {
@@ -136,7 +136,7 @@ function digium_phones_contacts($conf, $internal, $extension) {
                         $output[] = '    can_monitor="1"';
                     }
                 } else {
-                    $output[] = '    contact_type="sip|external"';
+                    //$output[] = '    contact_type="sip|external"';
                     if ($entry['settings']['subscribe_to'] != null && $entry['settings']['subscribe_to'] == 'on') {
                         if ($entry['settings']['subscription_url'] != null) {
                             $output[] = '    subscribe_to="' . htmlspecialchars($entry['settings']['subscription_url']) . '"';


### PR DESCRIPTION
This is a fix for a fail on non-array and also customer issue reported: https://community.freepbx.org/t/digium-phones-module-support-status-version-numbers-send-to-vm/39733 