### PR TITLE
Reimplement blf unused linekeys

### DIFF
--- a/conf/blf_generator.php
+++ b/conf/blf_generator.php
@@ -114,6 +114,15 @@ if (empty($limits[$model])) {
 $model_limits = $limits[$model];
 $lines_in_use = $_GET['lines'];
 
+if ($lines_in_use == -1) {
+	// blf on unused line keys is disabled
+	$lines_in_use = $model_limits['lines'];
+}
+if ($model_limits['lines'] == -1) {
+	// always start d80 at index 1
+	$lines_in_use = 1;
+}
+
 $xml = new SimpleXmlElement('<config/>');
 $smart_blf = $xml->addChild('smart_blf');
 $blf_items = $smart_blf->addChild('blf_items');

--- a/conf/res_digium_phone_devices.php
+++ b/conf/res_digium_phone_devices.php
@@ -121,7 +121,7 @@ function res_digium_phone_devices($conf) {
 				// ignore this value here and process it below
 				continue;
 			} elseif ($key == 'blf_unused_linekeys') {
-				// discard old user configured value
+				// don't pass to device anymore, this is used by smart blf now
 				continue;
 			} elseif ($key == 'send_to_vm') {
 				// discard old user configured value
@@ -158,6 +158,7 @@ function res_digium_phone_devices($conf) {
 		// create master list of enabled phonebooks
 		$phonebook_list = array();
 		$blf_id = $device['settings']['rapiddial'];
+		$blf_unused_linekeys = $device['settings']['blf_unused_linekeys'];
 		if (!empty($device['phonebooks'])) foreach ($device['phonebooks'] as $phonebook) {
 			$phonebook_list[] = $phonebook['phonebookid'];
 		}
@@ -178,7 +179,11 @@ function res_digium_phone_devices($conf) {
 
 			$doutput[] = "contact=contacts-$file_id.xml";
 			if ($id == $blf_id) {
-				$doutput[] = "blf_items=blf-$file_id.php?lines=$line_count";
+				if ($blf_unused_linekeys == 'no') {
+					$doutput[] = "blf_items=blf-$file_id.php?lines=-1";
+				} else {
+					$doutput[] = "blf_items=blf-$file_id.php?lines=$line_count";
+				}
 				$doutput[] = "blf_contact_group=$file_id";
 			}
 		}

--- a/module.xml
+++ b/module.xml
@@ -9,8 +9,9 @@
 	<licenselink>http://www.gnu.org/licenses/gpl-3.0.txt</licenselink>
 	<candisable>yes</candisable>
 	<canuninstall>yes</canuninstall>
-	<version>13.0.7.1</version>
+	<version>13.0.7.2</version>
 	<changelog>
+		*13.0.7.2* Reimplement blf unused linekeys
 		*13.0.7.1* D80 support, contacts/blf rewrite
 		*13.0.6* Embed licensing
 		*13.0.5.1* Embed license register code

--- a/page.digium_phones.php
+++ b/page.digium_phones.php
@@ -99,7 +99,7 @@ if (isset($_POST['general_submit'])) {
 		'timezone',
 		'web_ui_enabled',
 		'record_own_calls',
-//		'blf_unused_linekeys',
+		'blf_unused_linekeys',
 		'ntp_resync',
 		'active_ringtone',
 		'login_password',

--- a/views/digium_phones_phones.php
+++ b/views/digium_phones_phones.php
@@ -1097,12 +1097,10 @@ $table->add_row(array( 'data' => fpbx_label('Require Pin for Voicemail:', 'Enabl
 					<option value="no" ' . ($devices['settings']['vm_require_pin'] == 'no' ? 'selected' : '') . '>Disabled (Default)</option>
 					<option value="yes" ' . ($devices['settings']['vm_require_pin'] == 'yes' ? 'selected' : '') . '>Enabled</option></select>'));
 
-/*
-$table->add_row(array( 'data' => fpbx_label('Rapid Dials on Unused Line Keys:', 'By default, Line keys that do not have an extension assigned to them will be configured with Rapid Dial keys. This behavior may be disabled such that Rapid Dial keys begin assignment on the sidecar keys.')),
+$table->add_row(array( 'data' => fpbx_label('Rapid Dials on Unused Line Keys:', 'By default, Line keys that do not have an extension assigned to them will be configured with Rapid Dial keys. This behavior may be disabled such that Rapid Dial keys begin assignment on the sidecar keys.  Note: this only affects D50 and D70 models.')),
 				array( 'data' => '<select id="blf_unused_linekeys" name="blf_unused_linekeys">
-					<option value="yes" ' . ($devices['settings']['blf_unused_linekeys'] == 'yes' ? 'selected' : '') . '>Enabled</option>
-					<option value="no" ' . ($devices['settings']['blf_unused_linekeys'] == 'no' ? 'selected' : '') . '>Disabled (Default)</option></select>'));
-*/
+					<option value="yes" ' . ($devices['settings']['blf_unused_linekeys'] == 'yes' ? 'selected' : '') . '>Enabled (Default)</option>
+					<option value="no" ' . ($devices['settings']['blf_unused_linekeys'] == 'no' ? 'selected' : '') . '>Disabled</option></select>'));
 
 $table->add_row(array( 'data' => fpbx_label('Seconds between NTP sync:', 'Defines the interval (in seconds) in which time is resynchronized via NTP. Defaults to "86400".')),
 				array( 'data' => '<input type="text" id="ntp_resync" name="ntp_resync" value="' . $devices['settings']['ntp_resync'] . '" />'));


### PR DESCRIPTION
This restores the blf unused linekeys flag, and then uses it to trigger the same result in the new smart blf generator.